### PR TITLE
Fix iPad layout breaking after going to background

### DIFF
--- a/xDrip/Scenes/Home/Home/HomeViewController.swift
+++ b/xDrip/Scenes/Home/Home/HomeViewController.swift
@@ -259,6 +259,7 @@ class HomeViewController: NibViewController, HomeDisplayLogic {
     
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
+        guard UIApplication.shared.applicationState != .background else { return }
         if view.bounds.width >= view.bounds.height {
             carbsBolusStackView?.axis = .vertical
             glucoseDataStackView?.axis = .vertical


### PR DESCRIPTION
## Summary
Fix iPad layout breaking after going to background (Home button pressed).
Stop iPad home screen layout changing while app is in background mode.

