### PR TITLE
Fix catalyst pairing.

### DIFF
--- a/xDrip/Services/Bluetooth/DexcomG6/Logic/DexcomG6MessageWorker.swift
+++ b/xDrip/Services/Bluetooth/DexcomG6/Logic/DexcomG6MessageWorker.swift
@@ -112,6 +112,9 @@ final class DexcomG6MessageWorker {
     
     private func handleAuthResponse(_ response: DexcomG6AuthChallengeRxMessage) throws {
         guard response.authenticated else { throw DexcomG6Error.notAuthenticated }
+        #if targetEnvironment(macCatalyst)
+        isPaired = true
+        #else
         if response.paired {
             isPaired = true
         } else {
@@ -123,6 +126,7 @@ final class DexcomG6MessageWorker {
             delegate?.workerDidRequestPairing()
             subscribeForPairingApplicationState()
         }
+        #endif
     }
     
     private func subscribeForPairingApplicationState() {


### PR DESCRIPTION
## Summary
Special pairing logic is not required on macOS, unlike iOS. We can consider it paired right away.

 #### Checklist:
 - [x] I have added a brief description of the problem in the PR body.
 - [x] I have explained how I solved the problem in the PR body.
 - [x] I have covered possible edge cases and side effects.
 - [x] I have have attached screenshots to the PR of any UI change.
 - [x] I have checked that my changes work on iOS and macOS targets.
 - [x] I have checked that my changes work correctly on devices with and without a Home button.
 - [x] I have added unit tests for the new logic.
 - [x] I have achieved maximum possible code coverage for the new code.
 - [x] I have checked that my UI works correctly on both Light and Dark themes.

 #### Acceptance Criteria
Pairing of Dexcom G6 transmitter works on macOS.
