### PR TITLE
Fix bluetooth pairing request not appearing when application is in foreground.

### DIFF
--- a/xDrip/Services/Bluetooth/DexcomG6/Logic/DexcomG6MessageWorker.swift
+++ b/xDrip/Services/Bluetooth/DexcomG6/Logic/DexcomG6MessageWorker.swift
@@ -112,9 +112,6 @@ final class DexcomG6MessageWorker {
     
     private func handleAuthResponse(_ response: DexcomG6AuthChallengeRxMessage) throws {
         guard response.authenticated else { throw DexcomG6Error.notAuthenticated }
-        #if targetEnvironment(macCatalyst)
-        isPaired = true
-        #else
         if response.paired {
             isPaired = true
         } else {
@@ -124,9 +121,13 @@ final class DexcomG6MessageWorker {
             )
             createDataRequest(ofType: .keepAliveTx)
             delegate?.workerDidRequestPairing()
-            subscribeForPairingApplicationState()
+            
+            if UIApplication.shared.applicationState == .active {
+                createDataRequest(ofType: .pairRequestTx)
+            } else {
+                subscribeForPairingApplicationState()
+            }
         }
-        #endif
     }
     
     private func subscribeForPairingApplicationState() {


### PR DESCRIPTION
## Summary
Previously application was supposing it is in background state and waited for a foreground state.
Added logic to check current application state and if it's active, show pairing request immediately.

 #### Checklist:
 - [x] I have added a brief description of the problem in the PR body.
 - [x] I have explained how I solved the problem in the PR body.
 - [x] I have covered possible edge cases and side effects.
 - [x] I have have attached screenshots to the PR of any UI change.
 - [x] I have checked that my changes work on iOS and macOS targets.
 - [x] I have checked that my changes work correctly on devices with and without a Home button.
 - [x] I have added unit tests for the new logic.
 - [x] I have achieved maximum possible code coverage for the new code.
 - [x] I have checked that my UI works correctly on both Light and Dark themes.
