### PR TITLE
Respect units setting in home data section, statistics and history.

### DIFF
--- a/xDrip/Scenes/Home/Home/Workers/HomeGlucoseFormattingWorker.swift
+++ b/xDrip/Scenes/Home/Home/Workers/HomeGlucoseFormattingWorker.swift
@@ -132,16 +132,19 @@ final class HomeGlucoseFormattingWorker: HomeGlucoseFormattingWorkerProtocol {
         
         statsCalculationWorker.calculate(with: entries, lowThreshold: lowThreshold, highThreshold: highThreshold)
         
+        let avgGlucose = GlucoseUnit.convertFromDefault(statsCalculationWorker.mean)
+        let stdDeviation = GlucoseUnit.convertFromDefault(statsCalculationWorker.stdDev)
+        
         return Home.DataSectionViewModel(
             lowValue: String(format: "%0.1f%%", statsCalculationWorker.lowPercentage),
             lowTitle: String(format: "Low (<%0.1f)", lowThreshold),
             inRange: String(format: "%0.1f%%", statsCalculationWorker.normalPercentage),
             highValue: String(format: "%0.1f%%", statsCalculationWorker.highPercentage),
             highTitle: String(format: "High (>%0.1f)", highThreshold),
-            avgGlucose: String(format: "%0.1f \(unit)", statsCalculationWorker.mean),
+            avgGlucose: String(format: "%0.1f \(unit)", avgGlucose),
             a1c: String(format: "%0.1f%%", statsCalculationWorker.a1cDCCT),
             reading: "\(entries.count)",
-            stdDeviation: String(format: "%0.1f \(unit)", statsCalculationWorker.stdDev),
+            stdDeviation: String(format: "%0.1f \(unit)", stdDeviation),
             gvi: String(format: "%0.2f", statsCalculationWorker.gvi),
             pgs: String(format: "%0.2f", statsCalculationWorker.pgs),
             isShown: isShown

--- a/xDrip/Scenes/Stats/StatsRoot/StatsRootPresenter.swift
+++ b/xDrip/Scenes/Stats/StatsRoot/StatsRootPresenter.swift
@@ -104,17 +104,21 @@ final class StatsRootPresenter: StatsRootPresentationLogic {
             return "\(normal)/\(high)/\(low)"
             
         case .medianMeanBG:
-            let median = calculationWorker.median
-            let mean = calculationWorker.mean
+            let median = GlucoseUnit.convertFromDefault(calculationWorker.median)
+            let mean = GlucoseUnit.convertFromDefault(calculationWorker.mean)
             return String(format: "%0.2f/%0.2f %@", median, mean, response.unit.label)
             
         case .hba1cEst:
-            let ifcc = calculationWorker.a1cIFCC
+            let ifcc = GlucoseUnit.convertFromDefault(calculationWorker.a1cIFCC)
             let dcct = calculationWorker.a1cDCCT
             return String(format: "%0.2f %@ %0.1f%%", ifcc, response.unit.label, dcct)
             
         case .stdDev:
-            return String(format: "%0.2f %@", calculationWorker.stdDev, response.unit.label)
+            return String(
+                format: "%0.2f %@",
+                GlucoseUnit.convertFromDefault(calculationWorker.stdDev),
+                response.unit.label
+            )
             
         case .relativeSD:
             return "\(calculationWorker.relativeSD)%"


### PR DESCRIPTION
## Summary
Units were not respected on those screens. Added `GlucoseUnit.ConvertFromDefault`.
See [issue](https://github.com/Faifly/xDrip/issues/79).

 #### Checklist:
 - [x] I have added a brief description of the problem in the PR body.
 - [x] I have explained how I solved the problem in the PR body.
 - [x] I have covered possible edge cases and side effects.
 - [x] I have have attached screenshots to the PR of any UI change.
 - [x] I have checked that my changes work on iOS and macOS targets.
 - [x] I have checked that my changes work correctly on devices with and without a Home button.
 - [x] I have added unit tests for the new logic.
 - [x] I have achieved maximum possible code coverage for the new code.
 - [x] I have checked that my UI works correctly on both Light and Dark themes.

 #### Screenshots or GIFs (if appropriate)
![Simulator Screen Shot - iPhone 8 - 2020-08-31 at 19 24 45](https://user-images.githubusercontent.com/29488527/91742937-b0759c00-ebbf-11ea-9613-fb372b195602.png)
![Simulator Screen Shot - iPhone 8 - 2020-08-31 at 19 24 48](https://user-images.githubusercontent.com/29488527/91742942-b3708c80-ebbf-11ea-8265-78834d3d2467.png)

