### PR TITLE
Add forward time offset at the beginning of carbs and bolus charts

### DIFF
--- a/xDrip/Components/Charts/BaseHistoryView.swift
+++ b/xDrip/Components/Charts/BaseHistoryView.swift
@@ -105,7 +105,7 @@ class BaseHistoryView: UIView {
         updateChart()
     }
     
-    private func updateIntervals() {
+    func updateIntervals() {
         var endDate = Date() + forwardTimeOffset
         var globalDuration = globalInterval + forwardTimeOffset
         var localDuration = localInterval + forwardTimeOffset

--- a/xDrip/Components/Charts/EntriesHistoryView.swift
+++ b/xDrip/Components/Charts/EntriesHistoryView.swift
@@ -107,6 +107,13 @@ final class EntriesHistoryView: BaseHistoryView {
         leftLabelsView.isHidden = !showChart
     }
     
+    override func updateIntervals() {
+        super.updateIntervals()
+        if localInterval < .secondsPerDay {
+         localDateRange.duration += forwardTimeOffset
+        }
+    }
+    
     @objc func chartButtonClicked() {
         onChartButtonClicked()
     }

--- a/xDrip/Resources/en.lproj/Localizable.strings
+++ b/xDrip/Resources/en.lproj/Localizable.strings
@@ -290,6 +290,9 @@
 "settings_nightscout_cloud_backfill_send" = "Send";
 "settings_nightscout_cloud_backfill_date_title" = "Date";
 "settings_nightscout_cloud_backfill_section_footer" = "Choose the date for the oldest record to send to Nightscout. Use with care";
+"settings_nightscout_cloud_backfill_no_glucose_readings_found" = "Didn't find any glucose readings in that time period";
+"settings_nightscout_cloud_backfill_found_readings_and_treatments" = "Queued %d glucose readings and %d  treatments!";
+
 
 // Settings Units
 "settings_units_mgdl" = "mg/dL";
@@ -429,10 +432,6 @@ This setting will be applied to all future sensors";
 "settings_pump_user_info_label_text" = "If you have a pump connected to Nightscout, you can sync it with xDrip to display basal insulin.";
 "settings_pump_user_sync_button_title" = "Synchronise with NightScout";
 "settings_pump_user_unpair_button_title" = "Unpair pump";
-
-
-
-
 
 
 // Bluetooth Errors

--- a/xDrip/Resources/ru.lproj/Localizable.strings
+++ b/xDrip/Resources/ru.lproj/Localizable.strings
@@ -290,6 +290,9 @@
 "settings_nightscout_cloud_backfill_send" = "Отправить";
 "settings_nightscout_cloud_backfill_date_title" = "Дата";
 "settings_nightscout_cloud_backfill_section_footer" = "Выберите дату самой старой записи для отправки на Nightscout. Используйте с осторожностью";
+"settings_nightscout_cloud_backfill_no_glucose_readings_found" = "Значений глюкозы на указанный период времени не найдено";
+"settings_nightscout_cloud_backfill_found_readings_and_treatments" = "%d  значений глюкозы и %d тритментов поставлены в очередь!";
+
 
 // Settings Units
 "settings_units_mgdl" = "мг/дл";
@@ -428,10 +431,6 @@
 "settings_pump_user_info_label_text" = "Если у вас есть помпа, подключенная к сервису Nightscout, вы можете синхронизовать его с приложением, чтобы отобразить базальный инсулин.";
 "settings_pump_user_sync_button_title" = "Синхронизировать с NightScout";
 "settings_pump_user_unpair_button_title" = "Разорвать синхронизацию";
-
-
-
-
 
 
 // Bluetooth Errors

--- a/xDripTests/Scenes/Home/Home/HomeViewControllerTests.swift
+++ b/xDripTests/Scenes/Home/Home/HomeViewControllerTests.swift
@@ -128,4 +128,33 @@ final class HomeViewControllerTests: XCTestCase {
         XCTAssertTrue(spy.doShowTrainingsListCalled)
         XCTAssertTrue(spy.doShowBasalsListCalled)
     }
+    
+    func testUpdateIntervals() throws {
+        // Given
+        let spy = HomeBusinessLogicSpy()
+        sut.interactor = spy
+        let mirror = HomeViewControllerMirror(viewController: sut)
+        
+        // When
+        loadView()
+        let view = try XCTUnwrap(mirror.carbsHistoryView)
+        view.setLocalTimeFrame(.secondsPerHour)
+        
+        // Then
+        XCTAssertTrue(view.localDateRange.duration == view.localInterval + 2 * view.forwardTimeOffset)
+        
+        // When
+        
+        view.setLocalTimeFrame(12 * .secondsPerHour)
+        
+        // Then
+        XCTAssertTrue(view.localDateRange.duration == view.localInterval + 2 * view.forwardTimeOffset)
+        
+        // When
+        
+        view.setLocalTimeFrame(.secondsPerDay)
+        
+        // Then
+        XCTAssertTrue(view.localDateRange.duration == view.localInterval + view.forwardTimeOffset)
+    }
 }


### PR DESCRIPTION
## Summary
 Solve wrong visual presentation of carbs and bolus charts by adding forward time offset at the beginning.

 #### Checklist:
 - [x] I have added a brief description of the problem in the PR body.
 - [x] I have explained how I solved the problem in the PR body.
 - [x] I have covered possible edge cases and side effects.
 - [x] I have have attached screenshots to the PR of any UI change.
 - [x] I have checked that my changes work on iOS and macOS targets.
 - [x] I have checked that my changes work correctly on devices with and without a Home button.
 - [x] I have added unit tests for the new logic.
 - [x] I have achieved maximum possible code coverage for the new code.
 - [x] I have checked that my UI works correctly on both Light and Dark themes.

![Simulator Screen Shot - iPhone SE (2nd generation) - 2020-09-10 at 19 04 46](https://user-images.githubusercontent.com/45981658/92764523-2a1a4080-f39d-11ea-8446-15eac45cd6d2.png)

